### PR TITLE
Fix for some password managers

### DIFF
--- a/OtpField.php
+++ b/OtpField.php
@@ -23,6 +23,7 @@ class OtpField extends InputElement
         $this->attr('autofocus', 'on');
         $this->attr('autocomplete', 'one-time-code');
         $this->attr('inputmode', 'numeric');
+        $this->attr('type', 'tel');
         $this->useInput(false);
     }
 


### PR DESCRIPTION
Some password managers, such as KeePassXC, cannot automatically fill in the OTP
Must be <input type="tel" ... >
With this fix, everything works as it should