### PR TITLE
Add option to not detect user IP change

### DIFF
--- a/action/login.php
+++ b/action/login.php
@@ -272,7 +272,7 @@ class action_plugin_twofactor_login extends DokuWiki_Action_Plugin
             $provider->getProviderID(),
             (Manager::getInstance())->getUser(),
             $provider->getSecret(),
-            auth_browseruid(),
+            $this->getConf("useinternaluid") ? auth_browseruid() : $_SERVER['HTTP_USER_AGENT'],
             auth_cookiesalt(false, true),
         ]));
     }

--- a/conf/default.php
+++ b/conf/default.php
@@ -1,2 +1,3 @@
 <?php
 $conf["optinout"] = 'optin';
+$conf["useinternaluid"] = 1;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -1,2 +1,3 @@
 <?php
 $meta["optinout"] = array('multichoice', '_choices' => array('optin', 'optout', 'mandatory'));
+$meta["useinternaluid"] = array('onoff');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -4,3 +4,4 @@ $lang["optinout_o_optin"] = 'Opt-In';
 $lang["optinout_o_optout"] = 'Opt-Out';
 $lang["optinout_o_mandatory"] = 'Mandatory';
 
+$lang["useinternaluid"] = "If this option is off, DokuWiki will not require re-authentication in case of user IP change.";


### PR DESCRIPTION
Add option to not use IP to cookie hash, but only browser user agent string. This may useful for private or small team wiki. (Also see #4)